### PR TITLE
fix for BigEndian

### DIFF
--- a/lib/Horde/Mapi/Timezone.php
+++ b/lib/Horde/Mapi/Timezone.php
@@ -80,14 +80,13 @@ class Horde_Mapi_Timezone
                 . 'ldstbias';
         }
         $tz = unpack($format, base64_decode($data));
-        $tz['timezone'] = $tz['bias'];
-        $tz['timezonedst'] = $tz['dstbias'];
-
         if (!Horde_Mapi::isLittleEndian()) {
             $tz['bias'] = Horde_Mapi::chbo($tz['bias']);
             $tz['stdbias'] = Horde_Mapi::chbo($tz['stdbias']);
             $tz['dstbias'] = Horde_Mapi::chbo($tz['dstbias']);
         }
+        $tz['timezone'] = $tz['bias'];
+        $tz['timezonedst'] = $tz['dstbias'];
 
         return $tz;
     }

--- a/test/Horde/Mapi/TimezoneTest.php
+++ b/test/Horde/Mapi/TimezoneTest.php
@@ -126,7 +126,7 @@ class Horde_Mapi_TimezoneTest extends Horde_Test_Case
         foreach ($this->_packed as $tz => $blob) {
             $offsets = Horde_Mapi_Timezone::getOffsetsFromSyncTZ($blob);
             foreach ($this->_offsets[$tz] as $key => $value) {
-                $this->assertEquals($value, $offsets[$key]);
+                $this->assertEquals($value, $offsets[$key], "Comparing '$key' for '$tz'");
             }
         }
     }
@@ -142,7 +142,7 @@ class Horde_Mapi_TimezoneTest extends Horde_Test_Case
             $date = new Horde_Date('2011-07-01', $tz);
             $offsets = Horde_Mapi_Timezone::getOffsetsFromDate($date);
             foreach ($offsets as $key => $value) {
-                $this->assertEquals($expected[$key], $value);
+                $this->assertEquals($expected[$key], $value, "Comparing '$key' for '$tz'");
             }
         }
     }


### PR DESCRIPTION
We encounter erratic failure for this package in Fedora QA
https://apps.fedoraproject.org/koschei/package/php-horde-Horde-Mapi?collection=f28

On Little Endian, test suite passes
On Big Endian, test suite fails

See scratch build without the patch (only the error message improvement):
https://koji.fedoraproject.org/koji/taskinfo?taskID=23103335

```
PHPUnit 5.7.23 by Sebastian Bergmann and contributors.
..F...                                                              6 / 6 (100%)
Time: 198 ms, Memory: 6.00MB
There was 1 failure:
1) Horde_Mapi_TimezoneTest::testOffsetsFromSyncTZ
Comparing 'timezone' for 'America/Los_Angeles'
Failed asserting that -536805376 matches expected 480.
/builddir/build/BUILD/php-horde-Horde-Mapi-1.0.8/Horde_Mapi-1.0.8/test/Horde/Mapi/TimezoneTest.php:129
FAILURES!
```

See scratch build with this patch:
https://koji.fedoraproject.org/koji/taskinfo?taskID=23103388
