### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Mapi/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Mapi/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Mapi Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Mapi/MapiTest.php
+++ b/test/Horde/Mapi/MapiTest.php
@@ -16,7 +16,7 @@
  * @package    Mapi_Utils
  * @subpackage UnitTests
  */
-class Horde_Mapi_MapiTest extends PHPUnit_Framework_TestCase
+class Horde_Mapi_MapiTest extends Horde_Test_Case
 {
 
     public function testFiletimeToUnixTime()

--- a/test/Horde/Mapi/TimezoneTest.php
+++ b/test/Horde/Mapi/TimezoneTest.php
@@ -6,6 +6,7 @@
  * @category Horde
  * @package Mapi_Utils
  */
+#[\AllowDynamicProperties]
 class Horde_Mapi_TimezoneTest extends Horde_Test_Case
 {
 

--- a/test/Horde/Mapi/TimezoneTest.php
+++ b/test/Horde/Mapi/TimezoneTest.php
@@ -106,13 +106,13 @@ class Horde_Mapi_TimezoneTest extends Horde_Test_Case
     );
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_oldTimezone = date_default_timezone_get();
         date_default_timezone_set('America/New_York');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         date_default_timezone_set($this->_oldTimezone);
     }

--- a/test/Horde/Mapi/phpunit.xml
+++ b/test/Horde/Mapi/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-mapi/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-mapi/-/blob/debian-sid/debian/patches/1012_php8.2.patch
