### PR TITLE
Handle non-abbreviated timezones correctly

### DIFF
--- a/lib/Horde/Mapi/Timezone.php
+++ b/lib/Horde/Mapi/Timezone.php
@@ -293,7 +293,7 @@ class Horde_Mapi_Timezone
         if (isset($timezones[$expectedTimezone])) {
             return $expectedTimezone;
         } else {
-            return Horde_Date::getTimezoneAlias(current($timezones));
+            return Horde_Date::getTimezoneAlias(key($timezones));
         }
     }
 


### PR DESCRIPTION
Previously, the `getTimezone` function returned abbreviated timezone names based on the current transition, which worked for regions like Berlin, New York, and Madrid. However, for timezones without standard abbreviations such as Kathmandu, Manila, and Japan - the function returned invalid identifiers like `UTC+0545`.

This issue was from using `current($timezones)`, which retrieves the `abbr` from the matching transition. Instead, the correct timezone identifier is stored in the array key. This commit updates the logic to use the array key rather than the value, ensuring accurate timezone identifiers are returned for all regions.

Tested with `horde:6.0.0-beta1`