### PR TITLE
fix(mapi): guard timezone transition check against incomplete offsets

### DIFF
--- a/lib/Horde/Mapi/Timezone.php
+++ b/lib/Horde/Mapi/Timezone.php
@@ -388,7 +388,8 @@ class Horde_Mapi_Timezone
      */
     protected function _checkTransition(array $std, array $dst, array $offsets)
     {
-        if (empty($std) || empty($offsets)) {
+        if (empty($std) || empty($offsets)
+            || !isset($offsets['bias'], $offsets['stdbias'])) {
             return false;
         }
 


### PR DESCRIPTION
# fix(mapi): guard timezone transition check against incomplete offsets

## Summary

Prevent PHP warnings in `Horde_Mapi_Timezone::_checkTransition()` when the offset array lacks `bias` or `stdbias` keys. This occurs when `getTimezone()` is called with an empty or invalid MAPI timezone blob — observed during **EAS 16.0** calendar exception handling on iOS.

## Problem

`getListOfTimezones()` iterates all Olson timezone identifiers and calls `_checkTransition()` for each. When `$offsets` is incomplete (e.g. from a failed `unpack()` on an empty ActiveSync timezone blob), the method accessed undefined keys:

```
PHP ERROR: Undefined array key "bias"
PHP ERROR: Undefined array key "stdbias"
```

Because the loop runs over every timezone identifier, a single bad blob could produce hundreds of warnings in `horde.log`.

Typical trigger: EAS 16.0 sends exception `SYNC_MODIFY` without a `Timezone` element; upstream code called `Appointment::getTimezone()` on an empty blob before falling back to the series timezone.

## Solution

Extend the early-return guard in `_checkTransition()` to require `bias` and `stdbias` via `isset()` before arithmetic. Incomplete offset arrays are treated as non-matching timezones (return `false`), which is the correct semantic.

## Changes

**`lib/Horde/Mapi/Timezone.php`**

| Change | Detail |
|--------|--------|
| `_checkTransition()` | Return `false` when `$offsets['bias']` or `$offsets['stdbias']` are not set |

No API or behaviour change for valid MAPI timezone blobs.

## Related work

- **kronolith** (`Event.php`): avoids calling `getTimezone()` when the EAS message has no timezone blob (root-cause fix for exception MODIFY).
- This **mapi** change is defensive: prevents log spam if any caller passes invalid offset data.

## Test plan

- [ ] EAS 16.0: modify a recurring calendar instance on iOS → no `bias`/`stdbias` warnings in `horde.log`
- [ ] Normal calendar sync with valid `POOMCAL:Timezone` blobs still resolves timezones correctly
- [ ] `php -l` on modified file passes

## Commit message

```
fix(mapi): guard timezone transition check against incomplete offsets

Skip _checkTransition when bias or stdbias are missing from the offset
array, avoiding PHP warnings when parsing empty or invalid MAPI timezone
blobs from EAS 16.0 calendar exception requests.
```
