### PR TITLE
fix(mapi): validate MAPI timezone blobs before unpack()

### DIFF
--- a/lib/Horde/Mapi/Timezone.php
+++ b/lib/Horde/Mapi/Timezone.php
@@ -27,6 +27,11 @@
 class Horde_Mapi_Timezone
 {
     /**
+     * Minimum byte length of a TIME_ZONE_INFORMATION structure.
+     */
+    public const SYNC_TZ_BINARY_LENGTH = 172;
+
+    /**
      * Date to use as start date when iterating through offsets looking for a
      * transition.
      *
@@ -80,7 +85,17 @@ class Horde_Mapi_Timezone
                 . 'lstdbias/a64dstname/vdstyear/vdstmonth/vdstday/vdstweek/vdsthour/vdstminute/vdstsecond/vdstmillis/'
                 . 'ldstbias';
         }
-        $tz = unpack($format, base64_decode($data));
+        if (!is_string($data) || trim($data) === '') {
+            throw new Horde_Mapi_Exception('Invalid or empty MAPI timezone data');
+        }
+        $binary = base64_decode($data, true);
+        if ($binary === false || strlen($binary) < self::SYNC_TZ_BINARY_LENGTH) {
+            throw new Horde_Mapi_Exception('Invalid or empty MAPI timezone data');
+        }
+        $tz = unpack($format, $binary);
+        if ($tz === false) {
+            throw new Horde_Mapi_Exception('Unable to decode MAPI timezone data');
+        }
         if (!Horde_Mapi::isLittleEndian()) {
             $tz['bias'] = Horde_Mapi::chbo($tz['bias']);
             $tz['stdbias'] = Horde_Mapi::chbo($tz['stdbias']);

--- a/test/Unnamespaced/TimezoneTest.php
+++ b/test/Unnamespaced/TimezoneTest.php
@@ -11,6 +11,7 @@
 namespace Horde\Mapi\Test\Unnamespaced;
 
 use Horde_Test_Case;
+use Horde_Mapi_Exception;
 use Horde_Mapi_Timezone;
 use Horde_Date;
 
@@ -137,6 +138,21 @@ class TimezoneTest extends Horde_Test_Case
             $offsets = Horde_Mapi_Timezone::getOffsetsFromSyncTZ($blob);
             foreach ($this->_offsets[$tz] as $key => $value) {
                 $this->assertEquals($value, $offsets[$key], "Comparing '$key' for '$tz'");
+            }
+        }
+    }
+
+    /**
+     * Invalid or empty MAPI timezone blobs must not trigger unpack() warnings.
+     */
+    public function testOffsetsFromSyncTZRejectsInvalidData()
+    {
+        foreach (['', ' ', '====', 'x'] as $blob) {
+            try {
+                Horde_Mapi_Timezone::getOffsetsFromSyncTZ($blob);
+                $this->fail('Expected Horde_Mapi_Exception for blob ' . json_encode($blob));
+            } catch (Horde_Mapi_Exception $e) {
+                $this->assertInstanceOf(Horde_Mapi_Exception::class, $e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Validate ActiveSync/MAPI timezone blobs in `getOffsetsFromSyncTZ()` before calling `unpack()`
- Throw `Horde_Mapi_Exception` for empty, whitespace-only, invalid base64, or truncated input
- Add unit test coverage for invalid blobs

## Motivation
Kronolith ActiveSync imports can receive empty or invalid timezone blobs from iOS clients (notably EAS 16.0 exception MODIFY). Passing these to `unpack()` produced PHP warnings and follow-on errors when accessing the failed result.

## Changes
- Add `SYNC_TZ_BINARY_LENGTH` constant (172 bytes for `TIME_ZONE_INFORMATION`)
- Use strict `base64_decode()` and length checks before unpacking
- New `testOffsetsFromSyncTZRejectsInvalidData` test

## Test plan
- [x] `vendor/bin/phpunit -c phpunit.xml.dist test/Unnamespaced/TimezoneTest.php --filter testOffsetsFromSyncTZ`
- [ ] Kronolith EAS sync with recurring-series exception MODIFY from iOS (no warnings in Horde log)
